### PR TITLE
refactor: centralize session clearing

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,12 +687,7 @@
 
             if (storedRole && !allowedRoles.includes(storedRole)) {
                 console.warn('Invalid role in storage, clearing...');
-                localStorage.removeItem('userRole');
-                localStorage.removeItem('isLoggedIn');
-                localStorage.removeItem('loginTimestamp');
-                localStorage.removeItem('userEmail');
-                localStorage.removeItem('userId');
-                resetSignInButtonState();
+                clearUserSession();
                 return false;
             }
 
@@ -700,12 +695,7 @@
             const loginTimestamp = Number(localStorage.getItem('loginTimestamp'));
             if (loginTimestamp && (Date.now() - loginTimestamp > SESSION_DURATION_MS)) {
                 console.warn('Session expired, clearing storage...');
-                localStorage.removeItem('userRole');
-                localStorage.removeItem('isLoggedIn');
-                localStorage.removeItem('loginTimestamp');
-                localStorage.removeItem('userEmail');
-                localStorage.removeItem('userId');
-                resetSignInButtonState();
+                clearUserSession();
                 return false;
             }
 
@@ -1732,13 +1722,7 @@
                 state.userEmail = null;
                 state.userName = null;
                 state.userPlayerId = null;
-
-                localStorage.removeItem('userRole');
-                localStorage.removeItem('isLoggedIn');
-                localStorage.removeItem('loginTimestamp');
-                localStorage.removeItem('userEmail');
-                localStorage.removeItem('userId');
-                resetSignInButtonState();
+                clearUserSession();
                 showToast('You have been logged out.');
                 ui.mainApp.classList.add('hidden');
                 ui.roleSelectionOverlay.classList.remove('hidden');
@@ -1778,6 +1762,15 @@
             if (loadingOverlay) {
                 loadingOverlay.classList.add('hidden');
             }
+        }
+
+        function clearUserSession() {
+            localStorage.removeItem('userRole');
+            localStorage.removeItem('isLoggedIn');
+            localStorage.removeItem('loginTimestamp');
+            localStorage.removeItem('userEmail');
+            localStorage.removeItem('userId');
+            resetSignInButtonState();
         }
         async function loadUsers() {
             if (!state.db) return;
@@ -2710,11 +2703,7 @@
                         // If we can't get user data, clear everything
                         state.isLoggedIn = false;
                         state.userRole = null;
-                        localStorage.removeItem('userRole');
-                        localStorage.removeItem('isLoggedIn');
-                        localStorage.removeItem('loginTimestamp');
-                        localStorage.removeItem('userEmail');
-                        localStorage.removeItem('userId');
+                        clearUserSession();
                     }
                 } else {
                     // Not authenticated - check if we should show viewer mode
@@ -2726,11 +2715,7 @@
                         // Clear everything if not authenticated and not viewer
                         state.isLoggedIn = false;
                         state.userRole = null;
-                        localStorage.removeItem('userRole');
-                        localStorage.removeItem('isLoggedIn');
-                        localStorage.removeItem('loginTimestamp');
-                        localStorage.removeItem('userEmail');
-                        localStorage.removeItem('userId');
+                        clearUserSession();
                     }
                 }
 


### PR DESCRIPTION
## Summary
- add `clearUserSession` utility to remove user session keys and reset sign-in state
- replace repeated localStorage cleanup blocks with `clearUserSession` calls across validation, logout, and auth setup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a58f5d648326ba301c3a67993f99