### PR TITLE
Handle loading overlay during auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
 
-    <div id="loading-overlay" class="fixed inset-0 bg-gray-800 bg-opacity-75 z-60 flex items-center justify-center hidden">
+    <div id="loading-overlay" class="fixed inset-0 bg-gray-800 bg-opacity-75 z-60 flex items-center justify-center">
         <div class="bg-white dark:bg-gray-800 rounded-2xl p-8 text-center shadow-xl">
             <div class="spinner mx-auto mb-4"></div>
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Signing you in...</h3>
@@ -68,7 +68,7 @@
         </div>
     </div>
     <!-- Role Selection Overlay -->
-    <div id="role-selection-overlay" class="fixed inset-0 bg-gray-800 z-50 flex items-center justify-center p-4">
+    <div id="role-selection-overlay" class="fixed inset-0 bg-gray-800 z-50 flex items-center justify-center p-4 hidden">
         <div class="w-full max-w-sm text-center">
             <h1 class="text-4xl font-bold text-white mb-2">Burnaby Arms B</h1>
             <p class="text-lg text-gray-300 mb-8">Darts Scorer</p>


### PR DESCRIPTION
## Summary
- Show loading spinner by default and hide role selection overlay until auth resolves
- Hide loading overlay on Firebase auth errors and after auth state determination
- Toggle main app or role selection based on user presence

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bc9187908326a73e050b306fe045