### PR TITLE
Reset match state after completion

### DIFF
--- a/app.js
+++ b/app.js
@@ -1784,6 +1784,8 @@
                 showToast("Match finished and all stats saved! Well played.", false);
                 ui.dotdModal.overlay.classList.add('hidden');
                 ui.dotdModal.overlay.classList.remove('flex');
+                state.fixture = { id: null, games: [] };
+                state.currentGameIndex = 0;
                 switchTab('match');
 
             } catch (e) {


### PR DESCRIPTION
## Summary
- Reset `fixture` and `currentGameIndex` before switching tabs when finishing a match
- Ensures the Current Match page clears immediately after saving stats

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af0d52d4108326a2b086361a6656f7