### PR TITLE
Return to scoring after team selection update

### DIFF
--- a/app.js
+++ b/app.js
@@ -2335,7 +2335,9 @@
                 try {
                     const fixtureRef = doc(state.db, FIXTURES_COLLECTION, state.fixture.id);
                     await updateDoc(fixtureRef, { games: games });
+                    state.fixture.games = games;
                     showToast("Team selections updated successfully!");
+                    switchTab('live');
                 } catch (error) {
                     console.error("Error updating teams:", error);
                     showToast("Could not update team selections.", true);

--- a/index.html
+++ b/index.html
@@ -2906,7 +2906,9 @@
                 try {
                     const fixtureRef = doc(state.db, FIXTURES_COLLECTION, state.fixture.id);
                     await updateDoc(fixtureRef, { games: games });
+                    state.fixture.games = games;
                     showToast("Team selections updated successfully!");
+                    switchTab('live');
                 } catch (error) {
                     console.error("Error updating teams:", error);
                     showToast("Could not update team selections.", true);


### PR DESCRIPTION
## Summary
- Update team selection flow to return users to the scoring tab
- Sync local fixture state when teams are updated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af0e6c9f7c83268637141959a9cbf1