### PR TITLE
Fix tab transitions overlay to prevent jumping

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
             </div>
 
             <!-- Tab Content Area -->
-            <div class="p-4 sm:p-6">
+            <div class="relative p-4 sm:p-6">
                 <!-- Current Match Tab -->
                 <div id="tab-content-match">
                     <div class="p-4 sm:p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700">
@@ -2023,10 +2023,10 @@
             render();
 
             if (currentPanel && newPanel) {
-                currentPanel.classList.add('tab-leave');
+                currentPanel.classList.add('tab-leave', 'absolute', 'w-full');
                 currentPanel.addEventListener('animationend', () => {
                     currentPanel.classList.add('hidden');
-                    currentPanel.classList.remove('tab-leave');
+                    currentPanel.classList.remove('tab-leave', 'absolute', 'w-full');
                 }, { once: true });
 
                 newPanel.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- ensure tab panels temporarily use absolute positioning during transitions
- make tab content container relative so leaving panel overlays correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1c501490832698c2502c0c200786