### PR TITLE
Improve loading overlay visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
 
-    <div id="loading-overlay" class="fixed inset-0 z-60 flex items-center justify-center bg-gradient-to-br from-green-800/90 to-gray-900/90 opacity-0 pointer-events-none transition-opacity duration-300">
+    <div id="loading-overlay" class="fixed inset-0 z-[9999] flex items-center justify-center bg-gradient-to-br from-green-800/90 to-gray-900/90 backdrop-blur-sm opacity-0 pointer-events-none transition-opacity duration-300">
         <div class="bg-white dark:bg-gray-800 rounded-2xl p-8 text-center shadow-xl">
             <img src="darts-icon-v3.png" alt="Loading..." class="spinner mx-auto mb-4">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Signing you in...</h3>


### PR DESCRIPTION
## Summary
- ensure loading overlay uses a valid high z-index
- blur content behind the loading spinner

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af1ed9f1d48326868ce78c17280f01