### PR TITLE
Use window.confetti to guard match celebration

### DIFF
--- a/index.html
+++ b/index.html
@@ -2514,8 +2514,8 @@
         }
 
         function openDotdModal() {
-            if (typeof confetti === 'function') {
-                confetti({ particleCount: 120, spread: 70, origin: { y: 0.6 } });
+            if (window.confetti) {
+                window.confetti({ particleCount: 120, spread: 70, origin: { y: 0.6 } });
             }
             showToast('Match Complete!');
             playMatchCompleteSound();


### PR DESCRIPTION
## Summary
- invoke confetti effect via `window.confetti` guard in `openDotdModal` to avoid direct global usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af242723948326a2ce11e780824843