### PR TITLE
feat: track player changes with turn sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,7 +626,7 @@
             previousFixtures: [],
             selectedPreviousFixtureId: null,
             currentGameIndex: 0,
-            previousPlayerNames: '',
+            lastTurnSeq: 0,
             confirmation: { action: null, data: null },
             loginAttemptRole: null,
             logoutTimer: null,
@@ -1392,9 +1392,10 @@
             });
             const namesText = playerNames.join(' & ');
             ui.currentPlayerNames.textContent = namesText;
-            if (state.previousPlayerNames !== namesText) {
+            const turnSeq = game.turnSeq || 0;
+            if (state.lastTurnSeq !== turnSeq) {
                 triggerPlayerChangeAnimation();
-                state.previousPlayerNames = namesText;
+                state.lastTurnSeq = turnSeq;
             }
             ui.gameNavTitle.textContent = game.title;
 
@@ -3019,8 +3020,24 @@
                     showToast("Could not update team selections.", 'error');
                 }
             };
-            ui.prevGameBtn.addEventListener('click', () => { if (state.currentGameIndex > 0) { state.currentGameIndex--; render(); } });
-            ui.nextGameBtn.addEventListener('click', () => { if (state.currentGameIndex < state.fixture.games.length - 1) { state.currentGameIndex++; render(); } });
+            ui.prevGameBtn.addEventListener('click', () => {
+                if (state.currentGameIndex > 0) {
+                    state.currentGameIndex--;
+                    const game = state.fixture.games[state.currentGameIndex];
+                    game.turnSeq = (game.turnSeq || 0) + 1;
+                    render();
+                    updateGameData();
+                }
+            });
+            ui.nextGameBtn.addEventListener('click', () => {
+                if (state.currentGameIndex < state.fixture.games.length - 1) {
+                    state.currentGameIndex++;
+                    const game = state.fixture.games[state.currentGameIndex];
+                    game.turnSeq = (game.turnSeq || 0) + 1;
+                    render();
+                    updateGameData();
+                }
+            });
 
             ui.liveMatchContent.addEventListener('click', (e) => {
                 const statBtn = e.target.closest('.stat-btn');


### PR DESCRIPTION
## Summary
- add `lastTurnSeq` to global state to track current turn
- increment `game.turnSeq` when navigating between games and persist updates
- trigger player change animation when `turnSeq` changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af27d526808326b0a3d31def353ca5