### PR TITLE
Improve active game highlight colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1242,7 +1242,7 @@
 
             state.fixture.games.forEach((game, index) => {
                 const gameEl = document.createElement('div');
-                gameEl.className = `p-4 rounded-xl ${state.currentGameIndex === index ? 'bg-emerald-50 dark:bg-emerald-900/50' : 'bg-gray-50 dark:bg-gray-700/50'}`;
+                gameEl.className = `p-4 rounded-xl ${state.currentGameIndex === index ? 'bg-emerald-100 dark:bg-emerald-800/60' : 'bg-gray-50 dark:bg-gray-700/50'}`;
                 const playerNames = game.playerIds.map(id => state.players.find(p => p.id === id)?.name || 'Unknown').join(' & ');
                 gameEl.innerHTML = `
                     <div class="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- make the active game's highlight brighter in light mode and darker in dark mode

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2e30a3c083269e374760b32b68e5