### PR TITLE
Default My Profile selection for admins

### DIFF
--- a/index.html
+++ b/index.html
@@ -2856,8 +2856,13 @@
         }
 
         function renderMyProfile() {
-            // If user is logged in and has a linked player ID, show their profile automatically
-            if (state.isLoggedIn && state.userPlayerId) {
+            // For admins, default to their own player when none selected
+            if (state.userRole === 'admin' && state.userPlayerId) {
+                state.myProfile.selectedPlayerId ||= state.userPlayerId;
+            }
+
+            // If a non-admin user is logged in and has a linked player ID, show their profile automatically
+            if (state.isLoggedIn && state.userPlayerId && state.userRole !== 'admin') {
                 state.myProfile.selectedPlayerId = state.userPlayerId;
                 const player = state.players.find(p => p.id === state.userPlayerId);
                 if (player) {
@@ -2880,7 +2885,7 @@
                 }
             }
 
-            // Fallback: Show player selector for manual selection (for users without linked profiles)
+            // Fallback: Show player selector for manual selection
             ui.myProfile.playerSelect.parentElement.classList.remove('hidden');
             const playerOptions = state.players.map(p => `<option value="${p.id}">${p.name}</option>`).join('');
             ui.myProfile.playerSelect.innerHTML = `<option value="">Select a player...</option>${playerOptions}`;


### PR DESCRIPTION
## Summary
- Default `selectedPlayerId` to the admin's own player ID when not already set
- Restrict automatic profile rendering to non-admin users, keeping admin selections persistent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c01d392c8326ab8ddb9a1e7cb410