### PR TITLE
Use dev icon when running locally

### DIFF
--- a/darts-icon-dev.svg
+++ b/darts-icon-dev.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#111827"/>
+  <text x="50" y="60" font-size="50" text-anchor="middle" fill="#10b981" font-family="Arial, sans-serif">DEV</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Burnaby Arms - Darts Scorer</title>
-    <link rel="apple-touch-icon" href="darts-icon-v3.png">
-    <link rel="manifest" href="manifest.json">
+    <link id="apple-icon" rel="apple-touch-icon" href="darts-icon-v3.png">
+    <link id="favicon" rel="icon" href="darts-icon-v3.png">
+    <link id="manifest-link" rel="manifest" href="manifest.json">
+    <script>
+        (function() {
+            const host = location.hostname;
+            const isDev = host === 'localhost' || host === '127.0.0.1' ||
+                host.includes('github.dev') || host.includes('codespaces') || host.includes('app.github.dev');
+            if (isDev) {
+                const devIcon = 'darts-icon-dev.svg';
+                document.getElementById('apple-icon').setAttribute('href', devIcon);
+                document.getElementById('favicon').setAttribute('href', devIcon);
+                document.getElementById('manifest-link').setAttribute('href', 'manifest.dev.json');
+            }
+        })();
+    </script>
     <meta name="theme-color" content="#10b981">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/manifest.dev.json
+++ b/manifest.dev.json
@@ -1,0 +1,20 @@
+{
+  "name": "Burnaby Arms B Darts Scorer",
+  "short_name": "Darts Scorer",
+  "description": "A web application for managing darts matches for the Burnaby Arms B team",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111827",
+  "theme_color": "#10b981",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "darts-icon-dev.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ],
+  "categories": ["sports", "games"],
+  "lang": "en"
+}


### PR DESCRIPTION
## Summary
- Swap favicon, apple-touch icon, and manifest to development versions when running on localhost or codespaces
- Add simple SVG dev icon and manifest for development builds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d7db1d688326b9b1cdfafe1576cd