### PR TITLE
Display background image on sign-in screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,16 +80,16 @@
   min-height: 100vh;
 }
 
-#main-app::before {
+body::before {
   content: '';
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   background-image: url('burnaby-logo.png');
   background-repeat: no-repeat;
-  background-position:  center 65%;
+  background-position: center 65%;
   background-size: 350px;
   opacity: 0.05;
   z-index: -1;
@@ -125,7 +125,7 @@
         </div>
     </div>
     <!-- Role Selection Overlay -->
-    <div id="role-selection-overlay" class="fixed inset-0 bg-gray-800 z-50 flex items-center justify-center p-4">
+    <div id="role-selection-overlay" class="fixed inset-0 bg-gray-800/70 z-50 flex items-center justify-center p-4">
         <div class="w-full max-w-sm text-center">
             <h1 class="text-4xl font-bold text-white mb-2">Burnaby Arms B</h1>
             <p class="text-lg text-gray-300 mb-8">Darts Scorer</p>


### PR DESCRIPTION
## Summary
- Render Burnaby Arms logo behind entire page by moving background image styles to `body`
- Make role selection overlay semi-transparent so background remains visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b852bbe1448326b662ccacb39da5cd