### PR TITLE
Add name field to account creation and show in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The Burnaby Arms B Darts Scorer is a web application for managing darts matches 
 
 ## Usage
 - Select your role or sign in with Google to access the app.
+- When creating an account, provide your name; it will appear in the admin user list.
 - Set up fixtures, record match scores, manage fines, and view player statistics.
 - Data is stored in your configured Firebase project.
 

--- a/index.html
+++ b/index.html
@@ -634,18 +634,22 @@ body::before {
     </div>
 
     <!-- Create Account Modal -->
-    <div id="signup-modal" class="fixed inset-0 bg-gray-900 bg-opacity-50 hidden items-center justify-center z-50 modal-overlay p-4">
-        <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6 w-full max-w-md">
-            <div class="flex justify-between items-center mb-4">
-                <h3 class="text-xl font-semibold dark:text-white">Create Account</h3>
-                <button id="signup-modal-close" class="text-gray-500 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white text-2xl leading-none">&times;</button>
-            </div>
-            <div class="space-y-4">
-                <div>
-                    <label for="signup-email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email</label>
-                    <input type="email" id="signup-email" placeholder="Enter your email" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+        <div id="signup-modal" class="fixed inset-0 bg-gray-900 bg-opacity-50 hidden items-center justify-center z-50 modal-overlay p-4">
+            <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6 w-full max-w-md">
+                <div class="flex justify-between items-center mb-4">
+                    <h3 class="text-xl font-semibold dark:text-white">Create Account</h3>
+                    <button id="signup-modal-close" class="text-gray-500 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white text-2xl leading-none">&times;</button>
                 </div>
-                <div>
+                <div class="space-y-4">
+                    <div>
+                        <label for="signup-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name</label>
+                        <input type="text" id="signup-name" placeholder="Enter your name" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                    </div>
+                    <div>
+                        <label for="signup-email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email</label>
+                        <input type="email" id="signup-email" placeholder="Enter your email" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                    </div>
+                    <div>
                     <label for="signup-password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Password</label>
                     <input type="password" id="signup-password" placeholder="Enter password" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
                 </div>
@@ -713,7 +717,8 @@ body::before {
             createUserWithEmailAndPassword,
             GoogleAuthProvider,
             signOut as firebaseSignOut,
-            onAuthStateChanged
+            onAuthStateChanged,
+            updateProfile
         } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
 
         const provider = new GoogleAuthProvider();
@@ -2025,13 +2030,14 @@ body::before {
         function openSignupModal() {
             document.getElementById('signup-modal').classList.remove('hidden');
             document.getElementById('signup-modal').classList.add('flex');
-            document.getElementById('signup-email').focus();
+            document.getElementById('signup-name').focus();
         }
 
         function closeSignupModal() {
             document.getElementById('signup-modal').classList.add('hidden');
             document.getElementById('signup-modal').classList.remove('flex');
             // Clear form
+            document.getElementById('signup-name').value = '';
             document.getElementById('signup-email').value = '';
             document.getElementById('signup-password').value = '';
             document.getElementById('signup-confirm-password').value = '';
@@ -2047,11 +2053,12 @@ body::before {
             signUpBtn.disabled = true;
             signUpBtn.textContent = 'Creating account...';
 
+            const name = document.getElementById('signup-name').value.trim();
             const email = document.getElementById('signup-email').value.trim();
             const password = document.getElementById('signup-password').value;
             const confirmPassword = document.getElementById('signup-confirm-password').value;
 
-            if (!email || !password || !confirmPassword) {
+            if (!name || !email || !password || !confirmPassword) {
                 showToast('Please fill in all fields.', 'warning');
                 resetEmailSignUpState();
                 return;
@@ -2074,6 +2081,7 @@ body::before {
 
             try {
                 const userCredential = await createUserWithEmailAndPassword(state.auth, email, password);
+                await updateProfile(userCredential.user, { displayName: name });
                 await handleSuccessfulSignIn(userCredential.user);
                 closeSignupModal();
                 showToast('Account created successfully!');


### PR DESCRIPTION
## Summary
- allow users to enter their name during email signup
- store signup name as displayName for user and show in admin list
- document name requirement in README

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b8588fac2883269e1cf9dd40baa4d2