### PR TITLE
Handle Firebase auth state and toggle overlays

### DIFF
--- a/src/firebase/init.js
+++ b/src/firebase/init.js
@@ -159,6 +159,38 @@ export function initFirebase() {
   state.db = db;
   state.auth = auth;
 
+  // Monitor authentication state
+  onAuthStateChanged(auth, (user) => {
+    // Update login state
+    state.isLoggedIn = !!user;
+
+    // Hide the loading overlay
+    const loadingOverlay = document.getElementById('loading-overlay');
+    if (loadingOverlay) {
+      loadingOverlay.classList.add('hidden');
+    }
+
+    // Show appropriate UI based on auth status
+    const roleSelection = document.getElementById('role-selection-overlay');
+    const mainApp = document.getElementById('main-app');
+
+    if (user) {
+      if (roleSelection) {
+        roleSelection.classList.add('hidden');
+      }
+      if (mainApp) {
+        mainApp.classList.remove('hidden');
+      }
+    } else {
+      if (roleSelection) {
+        roleSelection.classList.remove('hidden');
+      }
+      if (mainApp) {
+        mainApp.classList.add('hidden');
+      }
+    }
+  });
+
   return { app, db, auth, state };
 }
 


### PR DESCRIPTION
## Summary
- Listen for Firebase auth state changes to set login status.
- Hide loading overlay after auth and show appropriate UI based on user presence.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b86acefb3083268ae45ac13f6be736